### PR TITLE
Feat/Figma input url, create zustand store

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,22 @@
+import { useEffect } from "react";
+import { useAuthStore } from "./store/useAccessToken";
+import Main from "./pages/Main";
 import Login from "./pages/Login";
 
 function App() {
+  const { accessToken, setAccessToken } = useAuthStore();
+
+  useEffect(() => {
+    chrome.storage.local.get("data", (result) => {
+      if (result.data && result.data.access_token) {
+        setAccessToken(result.data.access_token);
+      }
+    });
+  }, [setAccessToken]);
+
   return (
-    <div className="w-80 flex items-center">
-      <Login />
+    <div className="min-w-80 flex items-center">
+      {accessToken ? <Main /> : <Login />}
     </div>
   );
 }

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -3,13 +3,23 @@ import React from "react";
 type ButtonProps = {
   onClick: () => void;
   children: React.ReactNode;
+  className?: string;
+  disabled?: boolean;
 };
 
-const Button: React.FC<ButtonProps> = ({ onClick, children }) => {
+const Button: React.FC<ButtonProps> = ({
+  onClick,
+  children,
+  className = "",
+  disabled = false,
+}) => {
   return (
     <button
       onClick={onClick}
-      className="bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-4 rounded shadow-md transition duration-300 ease-in-out"
+      className={`w-full py-2 text-white rounded shadow-md transition duration-300 ease-in-out ${
+        className || "bg-indigo-600 hover:bg-indigo-700"
+      }`}
+      disabled={disabled}
     >
       {children}
     </button>

--- a/src/components/UrlInput.tsx
+++ b/src/components/UrlInput.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+
+type UrlInputProps = {
+  value: string;
+  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  isValid: boolean | null;
+  placeholder: string;
+};
+
+const UrlInput: React.FC<UrlInputProps> = ({
+  value,
+  onChange,
+  isValid,
+  placeholder,
+}) => {
+  return (
+    <input
+      type="text"
+      className={`w-full p-2 mb-4 border rounded focus:outline-none focus:ring-2 ${
+        isValid === null
+          ? "focus:ring-green-500"
+          : isValid
+            ? "border-green-500 focus:ring-green-500"
+            : "border-red-500 focus:ring-red-500"
+      }`}
+      placeholder={placeholder}
+      value={value}
+      onChange={onChange}
+    />
+  );
+};
+
+export default UrlInput;

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -36,9 +36,11 @@ const Login: React.FC = () => {
   };
 
   return (
-    <div className="flex flex-col items-center justify-center p-8">
+    <div className="items-center justify-center p-8">
       <Introduction />
-      <Button onClick={clickev}>Figma 계정으로 로그인</Button>
+      <Button onClick={clickev} className="bg-indigo-600 hover:bg-indigo-700">
+        Figma 계정으로 로그인
+      </Button>
     </div>
   );
 };

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -1,0 +1,54 @@
+import { useState, useEffect } from "react";
+import { useAuthStore } from "../store/useAccessToken";
+import { isValidFigmaUrl } from "../utils/utils";
+
+import UrlInput from "../components/UrlInput";
+import Button from "../components/Button";
+
+const Main: React.FC = () => {
+  const { accessToken } = useAuthStore();
+  const [figmaUrl, setFigmaUrl] = useState("");
+  const [isValidUrl, setIsValidUrl] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    if (figmaUrl) {
+      setIsValidUrl(isValidFigmaUrl(figmaUrl));
+    } else {
+      setIsValidUrl(null);
+    }
+  }, [figmaUrl]);
+
+  const clickev = () => {
+    chrome.runtime.sendMessage({
+      action: "fetchDiffData",
+      figmaUrl: figmaUrl,
+      accessToken: accessToken,
+    });
+  };
+
+  return (
+    <div className="w-full p-8 bg-white rounded shadow-md">
+      <h1 className="text-center text-gray-700 mb-2">
+        피그마 파일 URL을 입력해주세요!
+      </h1>
+      <UrlInput
+        value={figmaUrl}
+        onChange={(ev) => setFigmaUrl(ev.target.value)}
+        isValid={isValidUrl}
+        placeholder="URL 입력"
+      />
+      {isValidUrl === false && (
+        <p className="text-center text-red-500 mb-4">유효한 URL이 아닙니다</p>
+      )}
+      <Button
+        onClick={clickev}
+        className={`${isValidUrl ? "bg-green-500" : "bg-gray-500 cursor-not-allowed"}`}
+        disabled={!isValidUrl}
+      >
+        제출하기
+      </Button>
+    </div>
+  );
+};
+
+export default Main;

--- a/src/store/useAccessToken.tsx
+++ b/src/store/useAccessToken.tsx
@@ -1,0 +1,11 @@
+import create from "zustand";
+
+interface AuthState {
+  accessToken: string | null;
+  setAccessToken: (token: string | null) => void;
+}
+
+export const useAuthStore = create<AuthState>((set) => ({
+  accessToken: null,
+  setAccessToken: (token) => set({ accessToken: token }),
+}));

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,0 +1,5 @@
+export function isValidFigmaUrl(url: string) {
+  const regex =
+    /^https:\/\/www\.figma\.com\/design\/[A-Za-z0-9]{22}\/[A-Za-z0-9-]+(\?node-id=[0-9-]+)?(&t=[A-Za-z0-9-]+)?$/;
+  return regex.test(url);
+}


### PR DESCRIPTION
### FigDiff

## [Figma Url Input](https://www.notion.so/FigDiff-cd08255c47ba43f5bccb6f4579f0d3fa?p=17c92effa3cd4db5aeb74bd0f4086c16&pm=s)

## Todo

- [x]  피그마 mockup URL을 입력받는데, 유효성 검사를 해야 합니다.
- [x]  피그마 url 형식에 맞지 않다면 input 창을 빨간색으로 바꿔주며 에러 메시지를 보여줍니다.
- [x]  유효성 검사가 완료되면 클릭 버튼이 활성화되며 제출 가능하게끔 바뀝니다.
- [x]  검증 통과 후 서버에 파일의 key와 token을 전달합니다.
- [ ]  해당 작업은 Capture Website 작업과 동시에 진행되어야 합니다.

## Description

스크린 캡쳐 로직 제외 모든 태스크 완료했습니다. 확인 부탁드리겠습니다! (_ _) 
`Button` 컴포넌트는 지금 색상이 Indigo가 디폴트로 되어있긴한데, props로 className을 받게하면서 다른 색상도 가능하게끔 수정하였습니다.
`Login` 컴포넌트도 flex 부분 수정했습니다. 확인 부탁드리겠습니다. 

## Concern (필요시)

- 리뷰 요청 부분 & 컨펌 필요 부분

## PR 전 확인사항

- [x] 가장 최신 브랜치를 pull
- [x] 브랜치명 확인하기
- [x] 코드 컨벤션을 모두 지키기
- [x] reviewer, assignee 확인하기
- [x] conflict가 모두 해결됐는지 확인하기

### 이미지 (필요시)

![Monosnap screencast 2024-07-05 01-00-31](https://github.com/FigDiff/figdiff-client/assets/126459089/ddaffff9-0101-41ea-b2d1-29683211aea7)


