### PR TITLE
Feat/Page Seperation

### DIFF
--- a/src/pages/Loading.tsx
+++ b/src/pages/Loading.tsx
@@ -1,7 +1,9 @@
 import React, { useEffect, useState } from "react";
+import Main from "./Main";
 import Spinner from "../components/Spinner";
 import CheckMark from "../components/CheckMark";
 import ErrorMark from "../components/ErrorMark";
+import Button from "../components/Button";
 
 interface LoadingProps {
   condition: boolean;
@@ -10,6 +12,7 @@ interface LoadingProps {
 
 const Loading: React.FC<LoadingProps> = ({ condition, error }) => {
   const [isLoading, setIsLoading] = useState(true);
+  const [showMain, setShowMain] = useState(false);
 
   useEffect(() => {
     if (error) {
@@ -23,25 +26,39 @@ const Loading: React.FC<LoadingProps> = ({ condition, error }) => {
     }
   }, [condition, error]);
 
+  const handleRetry = () => {
+    setShowMain(true);
+  };
+
+  if (showMain) {
+    return <Main />;
+  }
+
   return (
     <div className="flex flex-col items-center justify-center h-screen">
       {isLoading ? (
         <>
-          <p className="text-lg font-semibold text-gray-700">
+          <p className="text-lg font-semibold text-gray-700 mb-4">
             비교를 진행 중입니다. 잠시만 기다려주세요.
           </p>
           <Spinner />
         </>
       ) : error ? (
         <>
-          <p className="text-lg font-semibold text-red-700">
+          <p className="text-lg font-semibold text-red-700 mb-4">
             비교에 실패하였습니다. 다시 시도해주세요.
           </p>
           <ErrorMark />
+          <Button
+            onClick={handleRetry}
+            className="bg-red-500 hover:bg-red-700 mt-4"
+          >
+            URL 다시 입력하기
+          </Button>
         </>
       ) : (
         <>
-          <p className="text-lg font-semibold text-gray-700">
+          <p className="text-lg font-semibold text-gray-700 mb-4">
             비교가 완료되었습니다!
           </p>
           <CheckMark />

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { useAuthStore } from "../store/useAccessToken";
 import { isValidFigmaUrl } from "../utils/utils";
 
+import Loading from "../pages/Loading";
 import UrlInput from "../components/UrlInput";
 import Button from "../components/Button";
 
@@ -9,6 +10,7 @@ const Main: React.FC = () => {
   const { accessToken } = useAuthStore();
   const [figmaUrl, setFigmaUrl] = useState("");
   const [isValidUrl, setIsValidUrl] = useState<boolean | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
   const SERVER_URL = import.meta.env.VITE_SERVER_URL;
 
   useEffect(() => {
@@ -19,14 +21,20 @@ const Main: React.FC = () => {
     }
   }, [figmaUrl]);
 
-  const haldlePostData = () => {
+  const handlePostData = () => {
     chrome.runtime.sendMessage({
       action: "fetchDiffData",
       figmaUrl,
       accessToken,
       SERVER_URL,
     });
+
+    setIsLoading(true);
   };
+
+  if (isLoading) {
+    return <Loading condition={!isLoading} error={false} />;
+  }
 
   return (
     <div className="w-full p-8 bg-white rounded shadow-md">
@@ -43,7 +51,7 @@ const Main: React.FC = () => {
         <p className="text-center text-red-500 mb-4">유효한 URL이 아닙니다</p>
       )}
       <Button
-        onClick={haldlePostData}
+        onClick={handlePostData}
         className={`${isValidUrl ? "bg-green-500" : "bg-gray-500 cursor-not-allowed"}`}
         disabled={!isValidUrl}
       >

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,7 +4,7 @@ export default {
   theme: {
     extend: {
       animation: {
-        spin: "spin 1s linear infinite",
+        spin: "spin 3s linear infinite",
       },
       keyframes: {
         spin: {


### PR DESCRIPTION
### FigDiff

## [Loading Page](https://www.notion.so/FigDiff-cd08255c47ba43f5bccb6f4579f0d3fa?p=42c202a44d1b4646bc8a1683c60020d7&pm=s)

## [Result Page](https://www.notion.so/FigDiff-cd08255c47ba43f5bccb6f4579f0d3fa?p=00a957818c04471da20fadd402302f5a&pm=s)

## Todo

- [x] 기존 생성했던 Loading 페이지 컴포넌트를 Main 컴포넌트 내부에 위치시켜, 사용자가 URL 입력 완료 이후 버튼 클릭 시 Loading 페이지 컴포넌트를 렌더링 합니다.

- [x]  ❌ **실패 시**
    - [x]  실패 UI 표시 후 다시 URL 입력 창으로 이동할 수 있는 버튼이 보여집니다.

## Description

- Loading 페이지 컴포넌트를 Main 페이지 컴포넌트 내부로 이동시키는 작업과, diff 실패 시 다시 URL 입력 창으로 이동할 수 있는 기능을 추가했습니다.

## Concern (필요시)

- 현재 서버 단 diffing 알고리즘이 완성되지 않았기에, 비교 실패 시 보여주는 화면에 대한 테스트는 단순 클라이언트 단 상태관리를 통해 진행했습니다.
- 추후 서버 diffing 알고리즘 완료 이후 통합하는 작업 필요합니다!

## PR 전 확인사항

- [x] 가장 최신 브랜치를 pull
- [x] 브랜치명 확인하기
- [x] 코드 컨벤션을 모두 지키기
- [x] reviewer, assignee 확인하기
- [x] conflict가 모두 해결됐는지 확인하기

### 이미지 (필요시)
