### PR TITLE
Fix: Fix loading component to show result(success or failure)

### DIFF
--- a/src/pages/Loading.tsx
+++ b/src/pages/Loading.tsx
@@ -13,6 +13,7 @@ interface LoadingProps {
 const Loading: React.FC<LoadingProps> = ({ condition, error }) => {
   const [isLoading, setIsLoading] = useState(true);
   const [showMain, setShowMain] = useState(false);
+  const [isDataFetched, setIsDataFetched] = useState(false);
 
   useEffect(() => {
     if (error) {
@@ -26,6 +27,21 @@ const Loading: React.FC<LoadingProps> = ({ condition, error }) => {
     }
   }, [condition, error]);
 
+  useEffect(() => {
+    const messageListener = (message: { action: string }) => {
+      if (message.action === "renderDifferences") {
+        setIsDataFetched(true);
+        setIsLoading(false);
+      }
+    };
+
+    chrome.runtime.onMessage.addListener(messageListener);
+
+    return () => {
+      chrome.runtime.onMessage.removeListener(messageListener);
+    };
+  }, []);
+
   const handleRetry = () => {
     setShowMain(true);
   };
@@ -34,38 +50,46 @@ const Loading: React.FC<LoadingProps> = ({ condition, error }) => {
     return <Main />;
   }
 
-  return (
-    <div className="flex flex-col items-center justify-center h-screen">
-      {isLoading ? (
-        <>
-          <p className="text-lg font-semibold text-gray-700 mb-4">
-            비교를 진행 중입니다. 잠시만 기다려주세요.
-          </p>
-          <Spinner />
-        </>
-      ) : error ? (
-        <>
-          <p className="text-lg font-semibold text-red-700 mb-4">
-            비교에 실패하였습니다. 다시 시도해주세요.
-          </p>
-          <ErrorMark />
-          <Button
-            onClick={handleRetry}
-            className="bg-red-500 hover:bg-red-700 mt-4"
-          >
-            URL 다시 입력하기
-          </Button>
-        </>
-      ) : (
-        <>
-          <p className="text-lg font-semibold text-gray-700 mb-4">
-            비교가 완료되었습니다!
-          </p>
-          <CheckMark />
-        </>
-      )}
-    </div>
-  );
+  if (isLoading) {
+    return (
+      <div className="flex flex-col items-center justify-center w-full h-screen">
+        <p className="text-lg text-center font-semibold w-full text-gray-700 mb-4">
+          비교를 진행 중입니다. 잠시만 기다려주세요.
+        </p>
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center w-full h-screen">
+        <p className="text-lg text-center font-semibold w-full text-red-700 mb-4">
+          비교에 실패하였습니다. 다시 시도해주세요.
+        </p>
+        <ErrorMark />
+        <Button
+          onClick={handleRetry}
+          className="bg-red-500 hover:bg-red-700 mt-4 w-full"
+        >
+          URL 다시 입력하기
+        </Button>
+      </div>
+    );
+  }
+
+  if (isDataFetched) {
+    return (
+      <div className="flex flex-col items-center justify-center w-full h-screen">
+        <p className="text-lg font-semibold text-gray-700 mb-4">
+          비교가 완료되었습니다!
+        </p>
+        <CheckMark />
+      </div>
+    );
+  }
+
+  return null;
 };
 
 export default Loading;


### PR DESCRIPTION
### FigDiff

## [[CE] Loading Page](https://www.notion.so/FigDiff-cd08255c47ba43f5bccb6f4579f0d3fa?p=42c202a44d1b4646bc8a1683c60020d7&pm=s)
## [[CE] Result Page](https://www.notion.so/FigDiff-cd08255c47ba43f5bccb6f4579f0d3fa?p=00a957818c04471da20fadd402302f5a&pm=s)

## Todo

- [x]  성공과 실패시 다른 UI를 보여줍니다
- [x]  **성공 시**
    - [x]  ‘비교가 완료되었습니다’ 라는 문구가 표시됩니다
    - [x]  중앙에 초록색 체크 마크가 존재합니다.
    - [x]  성공 UI 표시 후 3초 뒤 자동으로 익스텐션 창이 닫힙니다.
- [x]  **실패 시**
    - [x]  ‘비교에 실패 하였습니다’ 라는 문구가 표시됩니다.
    - [x]  중앙에 빨간색 X 마크가 존재합니다.
    - [ ]  실패 이유에 대한 설명을 표시해줍니다.
    - [ ]  실패 UI 표시 후 3초 뒤 자동으로 URL 입력 창으로 이동합니다.

## Description

- 피그마와 웹사이트를 비교하는 로딩이 끝난 후 해당 결과에 따라 성공 혹은 실패 결과페이지를 보여줍니다.
- 실패 페이지에 대한 상세 내용은 아직 서버측에서 에러 관련 메시지를 설정하지 않아 완료하지 않았습니다 추후 추가하겠습니다.

## Concern (필요시)

- 리뷰 요청 부분 & 컨펌 필요 부분

## PR 전 확인사항

- [x] 가장 최신 브랜치를 pull
- [x] 브랜치명 확인하기
- [x] 코드 컨벤션을 모두 지키기
- [x] reviewer, assignee 확인하기
- [x] conflict가 모두 해결됐는지 확인하기

### 이미지 (필요시)
