### PR TITLE
Feat/server upload diff img screen img

### DIFF
--- a/public/checkUserId.js
+++ b/public/checkUserId.js
@@ -8,7 +8,7 @@ chrome.storage.local.get(["data", "WEB_URL"], (result) => {
   const WEB_URL = result.WEB_URL;
 
   if (userId) {
-    window.location.href = `${WEB_URL}/${userId}`;
+    window.location.href = `${WEB_URL}/dash`;
   } else {
     window.location.href = `${WEB_URL}`;
   }

--- a/public/renderDifferences.js
+++ b/public/renderDifferences.js
@@ -15,15 +15,18 @@ function renderDifferences(data) {
   const screenshotImage = document.createElement("img");
 
   screenshotImage.classList.add("screenshot-image");
-
   screenshotImage.src = screenshotUrl;
-
   screenshotImage.style.position = "absolute";
-  screenshotImage.style.left = "1.5px";
-  screenshotImage.style.top = "1.5px";
-  screenshotImage.style.border = "0px";
+  screenshotImage.style.left = "0px";
+  screenshotImage.style.top = "0px";
 
   document.body.appendChild(screenshotImage);
+
+  const diffContainer = document.createElement("div");
+  diffContainer.classList.add("diff-Container");
+  diffContainer.style.position = "absolute";
+  diffContainer.style.left = "0px";
+  diffContainer.style.top = "0px";
 
   data.differentFigmaNodes.forEach((node, index) => {
     const { x, y, width, height } = node.absoluteBoundingBox;
@@ -31,26 +34,22 @@ function renderDifferences(data) {
     const blob = new Blob([imageBuffer], { type: "image/png" });
     const imageUrl = URL.createObjectURL(blob);
 
-    const diffContainer = document.createElement("div");
-
-    diffContainer.classList.add("figma-image");
-
-    diffContainer.style.position = "absolute";
-    diffContainer.style.left = `${x}px`;
-    diffContainer.style.top = `${y}px`;
-    diffContainer.style.width = `${width}px`;
-    diffContainer.style.height = `${height}px`;
-    diffContainer.style.zIndex = "9999";
-    diffContainer.style.pointerEvents = "none";
-    diffContainer.style.border = "2px solid green";
-    diffContainer.style.opacity = "0.2";
-
     const diffImage = document.createElement("img");
+    diffImage.classList.add("figma-image");
+    diffImage.style.position = "absolute";
+    diffImage.style.left = `${x}px`;
+    diffImage.style.top = `${y}px`;
+    diffImage.style.width = `${width}px`;
+    diffImage.style.height = `${height}px`;
+    diffImage.style.zIndex = "9999";
+    diffImage.style.pointerEvents = "none";
+    diffImage.style.border = "2px solid green";
     diffImage.src = imageUrl;
 
     diffContainer.appendChild(diffImage);
-    document.body.appendChild(diffContainer);
   });
+
+  document.body.appendChild(diffContainer);
 
   createCombinedOpacityControl();
 }
@@ -124,9 +123,7 @@ function createCombinedOpacityControl() {
 
   figmaSlider.addEventListener("input", () => {
     const opacityValue = figmaSlider.value / 100;
-    document.querySelectorAll(".figma-image").forEach((element) => {
-      element.style.opacity = opacityValue;
-    });
+    document.querySelector(".diff-Container").style.opacity = opacityValue;
   });
 
   webpageSlider.addEventListener("mousedown", (e) => {

--- a/public/takeScreenShot.js
+++ b/public/takeScreenShot.js
@@ -1,0 +1,105 @@
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.action === "canvasScreenShot") {
+    takeScreenshot()
+      .then((result) => {
+        sendResponse({ status: "success", result });
+      })
+      .catch((error) => {
+        sendResponse({ status: "error", message: error.message });
+      });
+
+    return true;
+  }
+});
+
+async function takeScreenshot() {
+  try {
+    const screenshotImage = document.querySelector(".screenshot-image");
+    const diffContainer = document.querySelector(".diff-Container");
+
+    if (!screenshotImage) {
+      throw new Error("No element with class 'screenshot-image' found");
+    }
+
+    const screenshotBase64 = await captureScreenshotImage(screenshotImage);
+    const diffBase64 = diffContainer
+      ? await captureDiffContainer(diffContainer, screenshotImage)
+      : null;
+
+    return { screenshotBase64, diffBase64 };
+  } catch (error) {
+    console.error("Error taking screenshot:", error);
+    throw error;
+  }
+}
+
+function captureScreenshotImage(imageElement) {
+  const canvas = document.createElement("canvas");
+  const ctx = canvas.getContext("2d");
+
+  if (!ctx) {
+    throw new Error("Failed to get canvas context");
+  }
+
+  canvas.width = imageElement.naturalWidth;
+  canvas.height = imageElement.naturalHeight;
+
+  ctx.drawImage(imageElement, 0, 0, canvas.width, canvas.height);
+
+  return new Promise((resolve) => {
+    resolve(canvas.toDataURL("image/png"));
+  });
+}
+
+async function captureDiffContainer(containerElement, referenceImage) {
+  const canvas = document.createElement("canvas");
+  const ctx = canvas.getContext("2d");
+
+  if (!ctx) {
+    throw new Error("Failed to get canvas context");
+  }
+
+  canvas.width = referenceImage.naturalWidth;
+  canvas.height = referenceImage.naturalHeight;
+
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+  const images = Array.from(containerElement.getElementsByTagName("img"));
+
+  const imagePromises = images.map(
+    (img) =>
+      new Promise((resolve, reject) => {
+        const image = new Image();
+        image.crossOrigin = "Anonymous";
+        image.src = img.src;
+
+        image.onload = () => {
+          const imgRect = img.getBoundingClientRect();
+          const refRect = referenceImage.getBoundingClientRect();
+          const x = imgRect.left - refRect.left;
+          const y = imgRect.top - refRect.top;
+          resolve({
+            image,
+            x,
+            y,
+            width: imgRect.width,
+            height: imgRect.height,
+          });
+        };
+        image.onerror = reject;
+      }),
+  );
+
+  const loadedImages = await Promise.all(imagePromises);
+
+  loadedImages.forEach(({ image, x, y, width, height }) => {
+    ctx.drawImage(image, x, y, width, height);
+    ctx.strokeStyle = "green";
+    ctx.lineWidth = 2;
+    ctx.strokeRect(x, y, width, height);
+  });
+
+  return new Promise((resolve) => {
+    resolve(canvas.toDataURL("image/png"));
+  });
+}

--- a/src/pages/Loading.tsx
+++ b/src/pages/Loading.tsx
@@ -103,7 +103,9 @@ const Loading: React.FC = () => {
   };
 
   const handleDataSave = () => {
-    // 데이터 저장 로직을 추가 작성해야합니다!
+    const SERVER_URL = import.meta.env.VITE_SERVER_URL;
+
+    chrome.runtime.sendMessage({ action: "takeScreenShot", SERVER_URL });
   };
 
   if (showMain) {

--- a/src/utils/base64ToFile.ts
+++ b/src/utils/base64ToFile.ts
@@ -1,0 +1,18 @@
+function base64ToBlob(base64: string, mimeType: string) {
+  const byteCharacters = atob(base64);
+  const byteNumbers = new Array(byteCharacters.length);
+
+  for (let i = 0; i < byteCharacters.length; i++) {
+    byteNumbers[i] = byteCharacters.charCodeAt(i);
+  }
+
+  const byteArray = new Uint8Array(byteNumbers);
+  return new Blob([byteArray], { type: mimeType });
+}
+
+function base64ToFile(base64: string, fileName: string, mimeType: string) {
+  const blob = base64ToBlob(base64, mimeType);
+  return new File([blob], fileName, { type: mimeType });
+}
+
+export default base64ToFile;

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -12,6 +12,11 @@
     "skipLibCheck": true,
     "outDir": "./dist"
   },
-  "include": ["vite.config.ts", "public/**/*.ts", "public/**/*.js"],
+  "include": [
+    "vite.config.ts",
+    "public/**/*.ts",
+    "public/**/*.js",
+    "src/utils/*.ts"
+  ],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
### FigDiff

## [[CE] Server upload diff img screen img](https://yummy-saw-ada.notion.site/CE-Server-upload-diff-img-screen-img-36e1f4625d994af7898b2ec7bcf0ae1f)

## Todo

- [x]  내역 저장하기를 클릭시 백그라운드.js와 content.js를 사용해야합니다.
- [x]  diff img와 screen img를 canvas를 이용해서 사진을 만들어야 합니다.
- [x]  userId는 쿼리로 넘겨줘야 합니다
- [x]  diff img와 screen img와 tabUrl는 바디에 넘겨줘야합니다

## Description

- 내역 저장하기를 클릭시 chrome.runtime.sendmessage를 사용하여 background를 트리거하였습니다.
- renderDifferences.js에 있는 변수명을 알맞게 바꿧습니다.
- base64 -> file로 만들기 위해 유틸함수를 만들었습니다.

## Concern (필요시)

- 리뷰 요청 부분 & 컨펌 필요 부분

## PR 전 확인사항

- [x] 가장 최신 브랜치를 pull
- [x] 브랜치명 확인하기
- [x] 코드 컨벤션을 모두 지키기
- [x] reviewer, assignee 확인하기
- [x] conflict가 모두 해결됐는지 확인하기

### 이미지 (필요시)
