### PR TITLE
Fix/figma url regex

### DIFF
--- a/public/background.ts
+++ b/public/background.ts
@@ -82,18 +82,33 @@ async function handleFetchDiffData(message: {
 
     const data = response.data;
 
-    chrome.scripting.executeScript(
-      {
-        target: { tabId },
-        files: ["renderDifferences.js"],
-      },
-      () => {
-        chrome.tabs.sendMessage(tabId, {
-          action: "renderDifferences",
-          data,
-        });
-      },
-    );
+    await new Promise<void>((resolve) => {
+      chrome.scripting.executeScript(
+        {
+          target: { tabId },
+          files: ["renderDifferences.js"],
+        },
+        () => {
+          chrome.tabs.sendMessage(
+            tabId,
+            {
+              action: "renderDifferences",
+              data,
+            },
+            () => {
+              if (chrome.runtime.lastError) {
+                console.error(
+                  "Error sending message:",
+                  chrome.runtime.lastError,
+                );
+              }
+
+              resolve();
+            },
+          );
+        },
+      );
+    });
   } catch (error) {
     chrome.runtime.sendMessage({ action: "serverError" });
 

--- a/public/renderDifferences.js
+++ b/public/renderDifferences.js
@@ -96,7 +96,7 @@ function createCombinedOpacityControl() {
   let offsetX, offsetY;
 
   controlBox.addEventListener("mousedown", (event) => {
-    if (event.targeventt !== webpageSlider && event.target !== figmaSlider) {
+    if (event.target !== webpageSlider && event.target !== figmaSlider) {
       isDragging = true;
       offsetX = event.clientX - controlBox.getBoundingClientRect().left;
       offsetY = event.clientY - controlBox.getBoundingClientRect().top;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,6 +1,6 @@
 export function isValidFigmaUrl(url: string) {
   const urlRegex =
-    /^https:\/\/www\.figma\.com\/design\/[A-Za-z0-9]{22}\/([A-Za-z0-9-._~%!$&'()*+,;=:@]|%[A-Fa-f0-9]{2})+(\?node-id=[0-9-]+)?(&t=[A-Za-z0-9-]+)?$/;
+    /^https:\/\/www\.figma\.com\/design\/[A-Za-z0-9]{22}\/([A-Za-z0-9-._~%!$&'()*+,;=:@]|%[A-Fa-f0-9]{2})+(\?node-id=[0-9-]+)?(&node-type=frame)(&t=[A-Za-z0-9-]+)?$/;
 
   return urlRegex.test(url);
 }


### PR DESCRIPTION
### FigDiff

## 칸반 외 작업

## Todo

- [x] Figma url 정규식에 node-type 추가
- [x] 비동기 함수가 끝나기전에 return 되는 현상 수정
- [x] renderDifferences.js에 오타 수정 

## Description

- Figma url 정규식에 node-type은 frame만 올 수 있게 변경

## Concern (필요시)

- Figma url이 변경되어서 유효하지 않은 url 오류가 계속 나타났습니다.

## PR 전 확인사항

- [x] 가장 최신 브랜치를 pull
- [x] 브랜치명 확인하기
- [x] 코드 컨벤션을 모두 지키기
- [x] reviewer, assignee 확인하기
- [x] conflict가 모두 해결됐는지 확인하기

### 이미지 (필요시)
